### PR TITLE
Tweak .my.cnf to avoid mysqldump error messages

### DIFF
--- a/root-files/opt/flownative/lib/beach.sh
+++ b/root-files/opt/flownative/lib/beach.sh
@@ -140,7 +140,10 @@ default-character-set = utf8
 host                  = ${BEACH_DATABASE_HOST}
 user                  = ${BEACH_DATABASE_USERNAME}
 password              = ${BEACH_DATABASE_PASSWORD}
+[mysql]
 database              = ${BEACH_DATABASE_NAME}
+[mysqldump]
+no-tablespaces
 EOM
 
     chown beach:beach /home/beach/.my.cnf


### PR DESCRIPTION
This avoids this rather cryptic error message when using mysqldump:

    Info: Using unique option prefix 'database' is error-prone and can break in the future.
    Please use the full name 'databases' instead.
    Warning: mysqldump: ignoring option '--databases' due to invalid value 'some-db-name'

And this one:

    mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS privilege(s)
    for this operation' when trying to dump tablespaces