### PR TITLE
Meaningful user service names

### DIFF
--- a/root-files/opt/flownative/lib/beach.sh
+++ b/root-files/opt/flownative/lib/beach.sh
@@ -234,8 +234,9 @@ beach_enable_user_services() {
     for servicePathAndFilename in ${servicePathsAndFilenames}
     do
         if [ -f "${servicePathAndFilename}" ]; then
-            cat > "${SUPERVISOR_BASE_PATH}/etc/conf.d/beach-user-${serviceNumber}.conf" <<- EOM
-[program:beach-user-${serviceNumber}]
+            serviceFilenameWithoutSuffix=$(basename ${servicePathAndFilename} .sh)
+            cat > "${SUPERVISOR_BASE_PATH}/etc/conf.d/${serviceFilenameWithoutSuffix}.conf" <<- EOM
+[program:${serviceFilenameWithoutSuffix}]
 process_name=%(program_name)s
 command=${servicePathAndFilename}
 autostart=true
@@ -245,7 +246,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 EOM
-            chmod 644 "${SUPERVISOR_BASE_PATH}/etc/conf.d/beach-user-${serviceNumber}.conf"
+            chmod 644 "${SUPERVISOR_BASE_PATH}/etc/conf.d/${serviceFilenameWithoutSuffix}.conf"
             chmod 775 "${servicePathAndFilename}"
 
             info "Beach: Enabled ${servicePathAndFilename} as user-defined service script"


### PR DESCRIPTION
User provided services contained in files like "beach-service-foo.sh" are now run as Supervisor services with the same name.

Previously, the name of Supervisor services was beach-user-1, beach-user-2 and so forth, and it was difficult to find out which service or process belonged to which beach-service-script. Now the original filename of the service script is used as a service name and can be easily discovered with `supervisorctl status`.

<img width="656" alt="image" src="https://user-images.githubusercontent.com/95582/219313201-f757180a-2215-4efe-965e-e9ad6f302f39.png">
