### PR TITLE
Fix banner skip detection

### DIFF
--- a/root-files/home/beach/.bashrc
+++ b/root-files/home/beach/.bashrc
@@ -1,6 +1,5 @@
-# If this shell was started by SSHD, the environment variables need to be set:
-if [[ -z "${FLOWNATIVE_LIB_PATH}" ]]; then
-    source /home/beach/.env
+# If not running interactively, skip the banner
+if [[ -z "$PS1" ]]; then
     export BANNER_FLOWNATIVE_SKIP="yes"
 fi
 


### PR DESCRIPTION
When `FLOWNATIVE_LIB_PATH` is not set, the commands later in the script will fail – so this is not a case that will happen.

OTOH skipping the banner unless in an interactive shell makes sense.

Related to flownative/localbeach#82