### PR TITLE
Drop hardcoded `/application` path

### DIFF
--- a/root-files/opt/flownative/beach-cron/beach-cron.sh
+++ b/root-files/opt/flownative/beach-cron/beach-cron.sh
@@ -2,10 +2,10 @@
 
 while true; do
     currentMinute=$(date +"%M")
-    if [ "${currentMinute}" == "15" ] && [[ -f "/application/beach-cron-hourly.sh" ]]; then
-        mkdir -p /application/Data/Logs/
-        chmod 775 /application/beach-cron-hourly.sh
-        /application/beach-cron-hourly.sh >> /application/Data/Logs/BeachCron.log 2>&1
+    if [ "${currentMinute}" == "15" ] && [[ -f "${BEACH_APPLICATION_PATH}/beach-cron-hourly.sh" ]]; then
+        mkdir -p ${BEACH_APPLICATION_PATH}/Data/Logs/
+        chmod 775 ${BEACH_APPLICATION_PATH}/beach-cron-hourly.sh
+        ${BEACH_APPLICATION_PATH}beach-cron-hourly.sh >> ${BEACH_APPLICATION_PATH}/Data/Logs/BeachCron.log 2>&1
         sleep 10
     fi
     sleep 55

--- a/root-files/opt/flownative/lib/beach.sh
+++ b/root-files/opt/flownative/lib/beach.sh
@@ -363,5 +363,5 @@ beach_finalize_flow() {
     fi
 
     debug "Beach: Writing .warmupdone flag"
-    touch /application/.warmupdone
+    touch ${BEACH_APPLICATION_PATH}/.warmupdone
 }


### PR DESCRIPTION
The handling of `.warmupdone` & `beach-cron-hourly.sh` used an hardcoded path instead of whatever `BEACH_APPLICATION_PATH` was set to.