### PR TITLE
Source .env (again) when logging in via SSH

### DIFF
--- a/root-files/home/beach/.bashrc
+++ b/root-files/home/beach/.bashrc
@@ -1,3 +1,8 @@
+# If this shell was started by SSHD, the environment variables need to be set:
+if [[ -z "${FLOWNATIVE_LIB_PATH}" ]]; then
+    source /home/beach/.env
+fi
+
 # If not running interactively, skip the banner
 if [[ -z "$PS1" ]]; then
     export BANNER_FLOWNATIVE_SKIP="yes"


### PR DESCRIPTION
This was broken with PR #18…