### PR TITLE
Sitemap crawler error handling

### DIFF
--- a/root-files/opt/flownative/sitemap-crawler/sitemap-crawler.php
+++ b/root-files/opt/flownative/sitemap-crawler/sitemap-crawler.php
@@ -69,6 +69,10 @@ final class SitemapCrawler
         }
 
         $parsedFirstUrl = parse_url($firstUrl);
+        if ($parsedFirstUrl === false) {
+            $this->log('Could not parse first URL: ' . $firstUrl);
+            exit(1);
+        }
         $internalFirstUrl = $this->internalBaseUrl . $parsedFirstUrl['path'] . (isset($parsedFirstUrl['query']) ? '?' . $parsedFirstUrl['query'] : '');
 
         $this->log(sprintf('Checking connectivity by retrieving %s, simulating host %s', $internalFirstUrl, $parsedFirstUrl['host']));
@@ -115,6 +119,10 @@ final class SitemapCrawler
                 $curlHandles = [];
                 foreach ($chunk as $i => $url) {
                     $parsedUrl = parse_url($url);
+                    if ($parsedUrl === false) {
+                        $this->log('Could not parse URL: ' . $url);
+                        continue;
+                    }
                     $url = $this->internalBaseUrl . $parsedUrl['path'] . (isset($parsedUrl['query']) ? '?' . $parsedUrl['query'] : '');
 
                     $curlHandles[$i] = curl_init($url);

--- a/root-files/opt/flownative/sitemap-crawler/sitemap-crawler.php
+++ b/root-files/opt/flownative/sitemap-crawler/sitemap-crawler.php
@@ -9,12 +9,12 @@
 
 if (PHP_MAJOR_VERSION >= 9) {
     echo "This script is not compatible with PHP 9 or higher yet\n";
-    exit (1);
+    exit(1);
 }
 
 if (getenv('FLOWNATIVE_LOG_PATH') === false) {
     echo "Missing environment variable FLOWNATIVE_LOG_PATH\n";
-    exit (1);
+    exit(1);
 }
 
 $internalBaseUrl = getenv('SITEMAP_CRAWLER_INTERNAL_BASE_URL');
@@ -53,7 +53,7 @@ final class SitemapCrawler
             $this->parseSitemap($sitemapUrl);
         } catch (\Throwable $throwable) {
             $this->log($throwable->getMessage());
-            exit (1);
+            exit(1);
         }
     }
 
@@ -141,7 +141,7 @@ final class SitemapCrawler
             }
         } catch (\Throwable $throwable) {
             $this->log($throwable->getMessage());
-            exit (1);
+            exit(1);
         }
     }
 

--- a/root-files/opt/flownative/sitemap-crawler/sitemap-crawler.php
+++ b/root-files/opt/flownative/sitemap-crawler/sitemap-crawler.php
@@ -63,6 +63,11 @@ final class SitemapCrawler
     public function crawl(): void
     {
         $firstUrl = reset($this->urls);
+        if ($firstUrl === false) {
+            $this->log('No first URL to parse.');
+            exit(0);
+        }
+
         $parsedFirstUrl = parse_url($firstUrl);
         $internalFirstUrl = $this->internalBaseUrl . $parsedFirstUrl['path'] . (isset($parsedFirstUrl['query']) ? '?' . $parsedFirstUrl['query'] : '');
 


### PR DESCRIPTION
Fixes this:
```
php Loading sitemap from https://www.acme.com/sitemap.xml ...
php [06-Aug-2025 14:15:58 Europe/Berlin] PHP Warning:  file_get_contents(https://www.acme.com/sitemap.xml): Failed to open stream: HTTP request failed! HTTP/1.1 502 Bad Gateway
php  in /opt/flownative/sitemap-crawler/sitemap-crawler.php on line 165
php [06-Aug-2025 14:15:58 Europe/Berlin] PHP Warning:  Undefined array key "host" in /opt/flownative/sitemap-crawler/sitemap-crawler.php on line 69
php Checking connectivity by retrieving http://localhost:8080, simulating host 
php [06-Aug-2025 14:16:01 Europe/Berlin] PHP Warning:  Undefined array key "host" in /opt/flownative/sitemap-crawler/sitemap-crawler.php on line 78
php Returned response code 400
php [06-Aug-2025 14:16:01 Europe/Berlin] PHP Warning:  Undefined array key "host" in /opt/flownative/sitemap-crawler/sitemap-crawler.php on line 78
php Returned response code 400
…
```