### PR TITLE
FEATURE: Add libavif-bin for AVIF image optimization

### DIFF
--- a/root-files/build.sh
+++ b/root-files/build.sh
@@ -57,7 +57,7 @@ build_tools() {
 # @return void
 #
 build_image_optimizers() {
-    packages_install optipng pngcrush pngquant gifsicle libjpeg-turbo-progs jpegoptim webp
+    packages_install optipng pngcrush pngquant gifsicle libjpeg-turbo-progs jpegoptim webp libavif-bin
 }
 
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds `libavif-bin` to `build_image_optimizers()` in `root-files/build.sh`, alongside the existing `jpegoptim` / `pngquant` / `webp` / etc. tooling.

`libavif-bin` provides the `avifenc` and `avifdec` CLIs, needed for AVIF post-processing — e.g. by [Sitegeist.Iconoclasm](https://github.com/sitegeist/Sitegeist.Iconoclasm) on Neos sites that now serve AVIF sources.

The package pulls in only `libavif` + `libyuv0`.

### Test

Built the patched image locally against `harbor.flownative.io/docker/php:8.4` and inspected the resulting container:

```
docker build --build-arg PHP_BASE_IMAGE=harbor.flownative.io/docker/php:8.4 -t beach-php-libavif-test .
docker run --rm --entrypoint sh beach-php-libavif-test -c \
  'which avifenc avifdec cwebp jpegoptim pngquant && avifenc --version | head -1'
```

Result:

```
/usr/bin/avifenc
/usr/bin/avifdec
/usr/bin/cwebp
/usr/bin/jpegoptim
/usr/bin/pngquant
Version: 0.11.1 (dav1d [dec]:1.0.0, libgav1 [dec]:0.18.0, aom [enc/dec]:v3.6.0, rav1e [enc]:0.5.1 (v0.5.1), svt [enc]:v1.4.1)
```

- New: `avifenc` / `avifdec` available (libavif 0.11.1 from Debian 12 bookworm).
- No regression: existing optimizers (`cwebp`, `jpegoptim`, `pngquant`) still present.
- Build completed cleanly with no new warnings beyond the pre-existing `InvalidDefaultArgInFrom` notice.