### PR TITLE
TASK: Warm caches for readiness probe

### DIFF
--- a/root-files/opt/flownative/lib/beach.sh
+++ b/root-files/opt/flownative/lib/beach.sh
@@ -376,8 +376,11 @@ beach_prepare_flow() {
 # @return void
 #
 beach_finalize_flow() {
+    # warm potential caches before the readiness probe hits this endpoint
+    curl http://127.0.0.1:8080/ >/dev/null 2>&1
+
     if [ ! -f "${BEACH_APPLICATION_PATH}"/flow ]; then
-        warn "Beach: No Flow application detected, skipping finialize"
+        warn "Beach: No Flow application detected, skipping finalize"
         return
     fi
 


### PR DESCRIPTION
Warm the application's caches during container startup, before the Kubernetes readiness probe starts hitting the instance, by issuing a single internal request to `http://127.0.0.1:8080/` at the start of `beach_finalize_flow()`.

After a deployment, the first request to an instance with a cold cache (Flow/Neos proxy classes + first render) can take considerably longer than the readiness probe's timeout (probe: `GET / :8080`, timeout 10s, every 15s). When that first render exceeds the timeout, the probe fails repeatedly; if it keeps failing for `progressDeadlineSeconds` (300s), the rollout is marked `ProgressDeadlineExceeded` and the deployment is reported as failed — even though the pod is healthy and would serve fine moments later.

By warming the homepage once during startup — before the readiness probe begins — the expensive first cache build happens out-of-band, so the probe gets a fast, cached response and the pod becomes ready quickly.