### PR TITLE
Do not fail container startup if warmup curl call fails

### DIFF
--- a/root-files/opt/flownative/lib/beach.sh
+++ b/root-files/opt/flownative/lib/beach.sh
@@ -377,7 +377,7 @@ beach_prepare_flow() {
 #
 beach_finalize_flow() {
     # warm potential caches before the readiness probe hits this endpoint
-    curl http://127.0.0.1:8080/ >/dev/null 2>&1
+    curl http://127.0.0.1:8080/ >/dev/null 2>&1 || true
 
     if [ ! -f "${BEACH_APPLICATION_PATH}"/flow ]; then
         warn "Beach: No Flow application detected, skipping finalize"


### PR DESCRIPTION
Especially in Local Beach that will never succeed, and blocked startup.